### PR TITLE
Bug fix: LocalAddr/RemoteAddr is nil

### DIFF
--- a/example/sctp.go
+++ b/example/sctp.go
@@ -11,19 +11,19 @@ import (
 	"git.cs.nctu.edu.tw/calee/sctp"
 )
 
-func serveClient(conn net.Conn, bufsize int) error {
+func serveClient(conn net.Conn, bufsize int) {
 	for {
 		buf := make([]byte, bufsize+128) // add overhead of SCTPSndRcvInfoWrappedConn
 		n, err := conn.Read(buf)
 		if err != nil {
 			log.Printf("read failed: %v", err)
-			return err
+			break
 		}
 		log.Printf("read: %d", n)
 		n, err = conn.Write(buf[:n])
 		if err != nil {
 			log.Printf("write failed: %v", err)
-			return err
+			break
 		}
 		log.Printf("write: %d", n)
 	}
@@ -69,7 +69,7 @@ func main() {
 			if err != nil {
 				log.Fatalf("failed to accept: %v", err)
 			}
-			log.Printf("Accepted Connection from RemoteAddr: %s", conn.RemoteAddr())
+			log.Printf("%s accepted connection from remote: %s", conn.LocalAddr(), conn.RemoteAddr())
 			wconn := sctp.NewSCTPSndRcvInfoWrappedConn(conn.(*sctp.SCTPConn))
 			if *sndbuf != 0 {
 				err = wconn.SetWriteBuffer(*sndbuf)

--- a/example/sctp.go
+++ b/example/sctp.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"git.cs.nctu.edu.tw/calee/sctp"
+	"github.com/free5gc/sctp"
 )
 
 func serveClient(conn net.Conn, bufsize int) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module git.cs.nctu.edu.tw/calee/sctp
+module github.com/free5gc/sctp
 
 go 1.14

--- a/sctp_linux.go
+++ b/sctp_linux.go
@@ -1,4 +1,5 @@
-// +build linux,!386
+//go:build linux && !386
+
 // Copyright 2019 Wataru Ishida. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -353,7 +354,10 @@ func (ln *SCTPListener) AcceptSCTP() (*SCTPConn, error) {
 
 	if events[0].Fd == int32(ln.fd) {
 		fd, _, err := syscall.Accept4(ln.fd, 0)
-		return NewSCTPConn(fd, nil), err
+		if err != nil {
+			return nil, err
+		}
+		return NewSCTPConn(fd, nil)
 	} else {
 		return nil, err
 	}
@@ -446,5 +450,5 @@ func dialSCTPExtConfig(network string, laddr, raddr *SCTPAddr, options InitMsg, 
 	if err != nil {
 		return nil, err
 	}
-	return NewSCTPConn(sock, nil), nil
+	return NewSCTPConn(sock, nil)
 }


### PR DESCRIPTION
- Once a connection is established, you can always retrieve the local or remote address, even if the peer has closed the connection.